### PR TITLE
Bump rake-n-bake to 1.3.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,8 +44,8 @@ GEM
     pry-byebug (3.1.0)
       byebug (~> 4.0)
       pry (~> 0.10)
-    rake (10.4.2)
-    rake-n-bake (1.1.4)
+    rake (10.5.0)
+    rake-n-bake (1.3.3)
       rake (~> 10)
       term-ansicolor (~> 1.3)
     rb-fsevent (0.9.4)
@@ -71,12 +71,12 @@ GEM
       simplecov-html (~> 0.9.0)
     simplecov-html (0.9.0)
     slop (3.6.0)
-    term-ansicolor (1.3.0)
+    term-ansicolor (1.3.2)
       tins (~> 1.0)
     thor (0.19.1)
     timers (4.0.1)
       hitimes
-    tins (1.3.5)
+    tins (1.9.0)
 
 PLATFORMS
   ruby
@@ -87,3 +87,6 @@ DEPENDENCIES
   rake-n-bake
   rspec
   simplecov
+
+BUNDLED WITH
+   1.11.2


### PR DESCRIPTION
Bumps [rake-n-bake](https://github.com/RichardVickerstaff/rake-n-bake) to 1.3.3.
- [Changelog](https://github.com/RichardVickerstaff/rake-n-bake/blob/master/history.rdoc)
- [Commits](https://github.com/RichardVickerstaff/rake-n-bake/commits)
