### PR TITLE
Bump simplecov to 0.11.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,13 +26,13 @@ GEM
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
     hitimes (1.2.2)
+    json (1.8.3)
     listen (2.10.0)
       celluloid (~> 0.16.0)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
     lumberjack (1.0.9)
     method_source (0.8.2)
-    multi_json (1.11.0)
     nenv (0.2.0)
     notiffany (0.0.6)
       nenv (~> 0.1)
@@ -65,11 +65,11 @@ GEM
       rspec-support (~> 3.2.0)
     rspec-support (3.2.2)
     shellany (0.0.1)
-    simplecov (0.9.2)
+    simplecov (0.11.2)
       docile (~> 1.1.0)
-      multi_json (~> 1.0)
-      simplecov-html (~> 0.9.0)
-    simplecov-html (0.9.0)
+      json (~> 1.8)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.0)
     slop (3.6.0)
     term-ansicolor (1.3.0)
       tins (~> 1.0)
@@ -87,3 +87,6 @@ DEPENDENCIES
   rake-n-bake
   rspec
   simplecov
+
+BUNDLED WITH
+   1.11.2


### PR DESCRIPTION
Bumps [simplecov](https://github.com/colszowka/simplecov) to 0.11.2.
- [Changelog](https://github.com/colszowka/simplecov/blob/master/CHANGELOG.md)
- [Commits](https://github.com/colszowka/simplecov/commits)
